### PR TITLE
Fix KG verifier event direction and tests path

### DIFF
--- a/src/tcdfkg/kg/__init__.py
+++ b/src/tcdfkg/kg/__init__.py
@@ -1,0 +1,1 @@
+# KG submodule initialization

--- a/src/tcdfkg/kg/verification.py
+++ b/src/tcdfkg/kg/verification.py
@@ -46,7 +46,7 @@ class KGVerifier:
                     ft = src.get("feature_type")
                     if ft:
                         G.add_node(f"Feature::{ft}")
-                        G.add_edge(f"Rule::{rule_ref}", f"Feature::{ft}")
+                        G.add_edge(f"Feature::{ft}", f"Rule::{rule_ref}")  # feature triggers rule
         return G
 
     def _s_struct(self, type_i: str, type_j: str) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 import os, random, numpy as np
 import pytest
+import sys  # ensure project src is on path
+
+# add src and build/lib directories for package discovery
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "build", "lib")))  #
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))  #
 
 try:
     import torch


### PR DESCRIPTION
## Summary
- ensure test environment finds package by adding src/build paths
- fix KG verification graph: event sources point to rules
- add missing `kg` package initializer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f2c0b448329948ec8e3f3b3ce89