### PR TITLE
Fix TCDF.fit error on short sequences

### DIFF
--- a/src/tcdfkg/causality/tcdf.py
+++ b/src/tcdfkg/causality/tcdf.py
@@ -69,6 +69,12 @@ class TCDF(nn.Module):
     def fit(self, X: np.ndarray, epochs=20, lr=1e-3, batch_size=64, verbose=True):
         # X: (N,T)
         N, T = X.shape; assert N == self.N
+        num_windows = T - self.w
+        if num_windows <= 0:
+            raise ValueError(
+                f"TCDF.fit needs at least one window but got X.shape={X.shape}, "
+                f"window={self.w} -> {num_windows} windows"
+            )
         windows, targets = [], []
         for t in range(self.w, T):
             windows.append(X[:, t-self.w:t]); targets.append(X[:, t])

--- a/tests/test_tcdf_windows_guard.py
+++ b/tests/test_tcdf_windows_guard.py
@@ -1,0 +1,11 @@
+import numpy as np
+import pytest
+from tcdfkg.causality.tcdf import TCDF
+
+def test_fit_raises_when_no_windows():
+    X = np.zeros((2, 5))
+    model = TCDF(num_series=2, window=10, dilations=(1,), kernel_size=3, hid_ch=4, dropout=0.0, device="cpu")
+    with pytest.raises(ValueError) as exc:
+        model.fit(X, epochs=1, lr=1e-3, batch_size=2, verbose=False)
+    msg = str(exc.value)
+    assert "window" in msg and "X.shape" in msg


### PR DESCRIPTION
## Summary
- Validate that TCDF.fit receives enough timesteps to form at least one window
- Add regression test for empty window condition

## Testing
- `pytest -q`
- `pytest tests/test_tcdf_windows_guard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba64d89b30832985a0e64c53591b55