### PR TITLE
Ensure TCDF window fits short series

### DIFF
--- a/configs/model_causal.yaml
+++ b/configs/model_causal.yaml
@@ -1,5 +1,5 @@
 tcdf:
-  window: 256
+  window: 128  # keep < sequence length (162) to ensure at least one training window
   dilations: [1,2,4,8,16]
   kernel_size: 3
   channels: 64


### PR DESCRIPTION
## Summary
- Reduce default TCDF window size to 128 so that training on short series (length 162) yields at least one window.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba6901037c8329ba4ebc42ad38dfd6