### PR TITLE
handle short series window

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -46,6 +46,14 @@ def main():
     Xn = (X - mu) / sd
 
     w = cfg.model_causal.get("encoder", cfg.model_causal).get("window", 256)
+    if X.shape[1] <= w:
+        w_new = max(1, X.shape[1] - 1)
+        print(f"[WARN] window {w} >= series length {X.shape[1]}; using window {w_new}")
+        if "encoder" in cfg.model_causal:
+            cfg.model_causal["encoder"]["window"] = w_new
+        else:
+            cfg.model_causal["window"] = w_new
+        w = w_new
     ds = WindowDataset(Xn, w=w, start=0, end=X.shape[1])
     dl = DataLoader(ds, batch_size=256, shuffle=False)
 

--- a/scripts/train_detector.py
+++ b/scripts/train_detector.py
@@ -53,6 +53,14 @@ def main():
 
     # windows & loaders
     w = cfg.model_causal.get("encoder", cfg.model_causal).get("window", 256)  # fallback nếu cấu hình gộp
+    if cut <= w:
+        w_new = max(1, cut - 1)
+        print(f"[WARN] window {w} >= series length {cut}; using window {w_new}")
+        if "encoder" in cfg.model_causal:
+            cfg.model_causal["encoder"]["window"] = w_new
+        else:
+            cfg.model_causal["window"] = w_new
+        w = w_new
     manom = cfg.model_causal if "encoder" in cfg.model_causal else None
     enc_cfg = cfg.model_causal["encoder"] if "encoder" in cfg.model_causal else cfg.model_causal
     attn_cfg = cfg.model_causal["attention"] if "attention" in cfg.model_causal else {"dmax": 32, "bias_mlp_hidden": 16}


### PR DESCRIPTION
## Summary
- avoid empty datasets by shrinking window size when series is shorter than configured window
- mirror same guard during evaluation

## Testing
- `pytest -q` *(fails: KeyboardInterrupt during torch import)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9110b6c08329a1eec5f53fef85ad